### PR TITLE
bonito/sargo: Mark vintf fragments as prebuilt xml's

### DIFF
--- a/bonito/Android.bp
+++ b/bonito/Android.bp
@@ -665,3 +665,57 @@ cc_prebuilt_library_shared {
 	prefer: true,
 	soc_specific: true,
 }
+
+prebuilt_etc_xml {
+        name: "android.hardware.identity.strongbox",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/android.hardware.identity.strongbox.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}
+
+prebuilt_etc_xml {
+        name: "android.hardware.keymaster@4.1-service.citadel",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/android.hardware.keymaster@4.1-service.citadel.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}
+
+prebuilt_etc_xml {
+        name: "android.hardware.weaver@1.0-service.citadel",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/android.hardware.weaver@1.0-service.citadel.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}
+
+prebuilt_etc_xml {
+        name: "manifest_android.hardware.drm@1.3-service.widevine",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/manifest_android.hardware.drm@1.3-service.widevine.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}
+
+prebuilt_etc_xml {
+        name: "manifest_wifi_ext",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/manifest_wifi_ext.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}
+
+prebuilt_etc_xml {
+        name: "rebootescrow-citadel",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/rebootescrow-citadel.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}

--- a/bonito/bonito-vendor.mk
+++ b/bonito/bonito-vendor.mk
@@ -678,12 +678,6 @@ PRODUCT_COPY_FILES += \
     vendor/google/bonito/proprietary/vendor/etc/sensors/config/sns_tilt.json:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/config/sns_tilt.json \
     vendor/google/bonito/proprietary/vendor/etc/sensors/config/tmd2725_0.json:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/config/tmd2725_0.json \
     vendor/google/bonito/proprietary/vendor/etc/sensors/sns_reg_config:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/sns_reg_config \
-    vendor/google/bonito/proprietary/vendor/etc/vintf/manifest/android.hardware.identity.strongbox.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/android.hardware.identity.strongbox.xml \
-    vendor/google/bonito/proprietary/vendor/etc/vintf/manifest/android.hardware.keymaster@4.1-service.citadel.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/android.hardware.keymaster@4.1-service.citadel.xml \
-    vendor/google/bonito/proprietary/vendor/etc/vintf/manifest/android.hardware.weaver@1.0-service.citadel.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/android.hardware.weaver@1.0-service.citadel.xml \
-    vendor/google/bonito/proprietary/vendor/etc/vintf/manifest/manifest_android.hardware.drm@1.3-service.widevine.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/manifest_android.hardware.drm@1.3-service.widevine.xml \
-    vendor/google/bonito/proprietary/vendor/etc/vintf/manifest/manifest_wifi_ext.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/manifest_wifi_ext.xml \
-    vendor/google/bonito/proprietary/vendor/etc/vintf/manifest/rebootescrow-citadel.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/rebootescrow-citadel.xml \
     vendor/google/bonito/proprietary/vendor/etc/default_b4.mps:$(TARGET_COPY_OUT_VENDOR)/etc/default_b4.mps \
     vendor/google/bonito/proprietary/vendor/etc/default_s4.mps:$(TARGET_COPY_OUT_VENDOR)/etc/default_s4.mps \
     vendor/google/bonito/proprietary/vendor/etc/flp.conf:$(TARGET_COPY_OUT_VENDOR)/etc/flp.conf \
@@ -1676,3 +1670,11 @@ PRODUCT_COPY_FILES += \
     vendor/google/bonito/proprietary/vendor/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/generic/common/WildCard/Wildcard/mcfg_sw.mbn:$(TARGET_COPY_OUT_VENDOR)/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/generic/common/WildCard/Wildcard/mcfg_sw.mbn \
     vendor/google/bonito/proprietary/vendor/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/mbn_sw.dig:$(TARGET_COPY_OUT_VENDOR)/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/mbn_sw.dig \
     vendor/google/bonito/proprietary/vendor/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/mbn_sw.txt:$(TARGET_COPY_OUT_VENDOR)/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/mbn_sw.txt
+
+PRODUCT_PACKAGES += \
+    android.hardware.identity.strongbox \
+    android.hardware.keymaster@4.1-service.citadel \
+    android.hardware.weaver@1.0-service.citadel \
+    manifest_android.hardware.drm@1.3-service.widevine \
+    manifest_wifi_ext \
+    rebootescrow-citadel

--- a/sargo/Android.bp
+++ b/sargo/Android.bp
@@ -654,3 +654,57 @@ cc_prebuilt_library_shared {
 	prefer: true,
 	soc_specific: true,
 }
+
+prebuilt_etc_xml {
+        name: "android.hardware.identity.strongbox",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/android.hardware.identity.strongbox.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}
+
+prebuilt_etc_xml {
+        name: "android.hardware.keymaster@4.1-service.citadel",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/android.hardware.keymaster@4.1-service.citadel.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}
+
+prebuilt_etc_xml {
+        name: "android.hardware.weaver@1.0-service.citadel",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/android.hardware.weaver@1.0-service.citadel.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}
+
+prebuilt_etc_xml {
+        name: "manifest_android.hardware.drm@1.3-service.widevine",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/manifest_android.hardware.drm@1.3-service.widevine.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}
+
+prebuilt_etc_xml {
+        name: "manifest_wifi_ext",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/manifest_wifi_ext.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}
+
+prebuilt_etc_xml {
+        name: "rebootescrow-citadel",
+        owner: "google",
+        src: "proprietary/vendor/etc/vintf/manifest/rebootescrow-citadel.xml",
+        filename_from_src: true,
+        sub_dir: "vintf/manifest",
+        soc_specific: true,
+}

--- a/sargo/sargo-vendor.mk
+++ b/sargo/sargo-vendor.mk
@@ -677,12 +677,6 @@ PRODUCT_COPY_FILES += \
     vendor/google/sargo/proprietary/vendor/etc/sensors/config/sns_tilt.json:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/config/sns_tilt.json \
     vendor/google/sargo/proprietary/vendor/etc/sensors/config/tmd2725_0.json:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/config/tmd2725_0.json \
     vendor/google/sargo/proprietary/vendor/etc/sensors/sns_reg_config:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/sns_reg_config \
-    vendor/google/sargo/proprietary/vendor/etc/vintf/manifest/android.hardware.identity.strongbox.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/android.hardware.identity.strongbox.xml \
-    vendor/google/sargo/proprietary/vendor/etc/vintf/manifest/android.hardware.keymaster@4.1-service.citadel.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/android.hardware.keymaster@4.1-service.citadel.xml \
-    vendor/google/sargo/proprietary/vendor/etc/vintf/manifest/android.hardware.weaver@1.0-service.citadel.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/android.hardware.weaver@1.0-service.citadel.xml \
-    vendor/google/sargo/proprietary/vendor/etc/vintf/manifest/manifest_android.hardware.drm@1.3-service.widevine.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/manifest_android.hardware.drm@1.3-service.widevine.xml \
-    vendor/google/sargo/proprietary/vendor/etc/vintf/manifest/manifest_wifi_ext.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/manifest_wifi_ext.xml \
-    vendor/google/sargo/proprietary/vendor/etc/vintf/manifest/rebootescrow-citadel.xml:$(TARGET_COPY_OUT_VENDOR)/etc/vintf/manifest/rebootescrow-citadel.xml \
     vendor/google/sargo/proprietary/vendor/etc/default_b4.mps:$(TARGET_COPY_OUT_VENDOR)/etc/default_b4.mps \
     vendor/google/sargo/proprietary/vendor/etc/default_s4.mps:$(TARGET_COPY_OUT_VENDOR)/etc/default_s4.mps \
     vendor/google/sargo/proprietary/vendor/etc/flp.conf:$(TARGET_COPY_OUT_VENDOR)/etc/flp.conf \
@@ -1674,3 +1668,11 @@ PRODUCT_COPY_FILES += \
     vendor/google/sargo/proprietary/vendor/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/generic/common/WildCard/Wildcard/mcfg_sw.mbn:$(TARGET_COPY_OUT_VENDOR)/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/generic/common/WildCard/Wildcard/mcfg_sw.mbn \
     vendor/google/sargo/proprietary/vendor/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/mbn_sw.dig:$(TARGET_COPY_OUT_VENDOR)/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/mbn_sw.dig \
     vendor/google/sargo/proprietary/vendor/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/mbn_sw.txt:$(TARGET_COPY_OUT_VENDOR)/rfs/msm/mpss/readonly/vendor/mbn/mcfg_sw/mbn_sw.txt
+
+PRODUCT_PACKAGES += \
+    android.hardware.identity.strongbox \
+    android.hardware.keymaster@4.1-service.citadel \
+    android.hardware.weaver@1.0-service.citadel \
+    manifest_android.hardware.drm@1.3-service.widevine \
+    manifest_wifi_ext \
+    rebootescrow-citadel


### PR DESCRIPTION
As of Android 11 copying vintf fragments with PRODUCT_COPY_FILES is considered an error, this is the cleanest way to deal with it.

Signed-off-by: Lunarixus <Nathan@Lunarixus.dev>